### PR TITLE
Available games only show to users who are not part of the game

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -9,13 +9,21 @@
 <h1> Available Games </h1>
 
 <% @available.each do |game| %>
-  <h2 class="text-center"> 
-    <%= link_to "Game #{game.id}", game_path(game) %> 
-    <br>
-  </h2>
+  <% if current_user %>
+    <% if game.white_player_id != current_user.id %>
+      <h2 class="text-center"> 
+        <%= link_to "Game #{game.id}", game_path(game) %> 
+        <br>
+      </h2>
+    <% end %>
+  <% else %>
+      <h2 class="text-center"> 
+        <%= link_to "Game #{game.id}", new_user_session_path %>
+      </h2>
+  <% end %>
 <% end %>
 
-<h1> Current Games </h1>
+<h1> Your Current Games </h1>
 <% if current_user %>
   <% @current.each do |game| %>
     <% if current_user.id == game.white_player_id || current_user.id == game.black_player_id %>

--- a/spec/helpers/pieces_helper_spec.rb
+++ b/spec/helpers/pieces_helper_spec.rb
@@ -11,5 +11,5 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe PiecesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  #pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
This updates the static view page such that the Available games only show to players who did not create the game. 

You can test this by creating two users. Create a game with one user. The game should not show up under available games. Login with the other user. You should see the game is listed under available. If you join the game, the game is no longer available. 

