### PR TITLE
Update knight valid move

### DIFF
--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -7,7 +7,7 @@ class Knight < Piece
 
 
   def valid_move?(new_row, new_column)
-    super
+    return false if super == false
     delta_row = (new_row - position_row).abs
     delta_col = (new_column - position_column).abs
     return false unless ((delta_row == 1) && (delta_col == 2)) || ((delta_row == 2) && (delta_col == 1))

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -4,9 +4,13 @@ class Knight < Piece
   end
 
    #should return false if move is greater than 1 space
-  def proper_length?(new_row, new_column)
+
+
+  def valid_move?(new_row, new_column)
+    super
     delta_row = (new_row - position_row).abs
     delta_col = (new_column - position_column).abs
-    ((delta_row == 1) && (delta_col == 2)) || ((delta_row == 2) && (delta_col == 1))
+    return false unless ((delta_row == 1) && (delta_col == 2)) || ((delta_row == 2) && (delta_col == 1))
+    true
   end
 end 

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -3,9 +3,6 @@ class Knight < Piece
     game.white_player_id == user_id ? '&#9816;' : '&#9822;'  
   end
 
-   #should return false if move is greater than 1 space
-
-
   def valid_move?(new_row, new_column)
     return false if super == false
     delta_row = (new_row - position_row).abs

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -35,8 +35,6 @@ class Piece < ApplicationRecord
   def valid_move?(new_row, new_column)
     return false if out_of_boundary?(new_row, new_column)
     return false if no_move?(new_row, new_column)
-    return false unless proper_length?(new_row, new_column)
-    true
   end
 
   def array_position(init, final)

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Knight, type: :model do
 
         it 'returns false if out of bounds for new_row' do
           #2 down then left and out of bounds
+          expect(@knight.out_of_boundary?(-2,0)).to be true
           expect(@knight.valid_move?(-2,0)).to be false
         end
 
@@ -57,11 +58,7 @@ RSpec.describe Knight, type: :model do
           # reposition knight
           @knight.position_row = 0
           @knight.position_column = 0
-          #puts " for in bound case should return false"
-          #p @knight.out_of_boundary?(0,2)
-          #puts " for out of bound case should return true"
-          #p @knight.out_of_boundary?(-2,2)
-          #2 down then right and out of bounds
+          expect(@knight.out_of_boundary?(2,-1)).to be true
           expect(@knight.valid_move?(2,-1)).to be false
         end
 

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Knight, type: :model do
     @knight = Knight.first #white Knight @ position_row: 0, position_column: 1
   end
 
-  describe "Knight\'s movement" do
+  describe "\'s movement" do
       context 'no_move?' do 
         it 'returns true for no move' do
           expect(@knight.no_move?(0,1)).to be true
@@ -16,41 +16,6 @@ RSpec.describe Knight, type: :model do
 
         it 'returns false for move' do
           expect(@knight.no_move?(0,2)).to be false
-        end
-      end
-
-      context 'proper_length?' do 
-        it 'returns true for L space vertical' do
-          #2 up then left
-          expect(@knight.proper_length?(2,0)).to be true
-          #2 up then right
-          expect(@knight.proper_length?(2,2)).to be true
-          #2 down then left
-          expect(@knight.proper_length?(-2,0)).to be true
-          #2 down then right
-          expect(@knight.proper_length?(-2,2)).to be true
-        end
-
-         it 'returns true for L space horizontal' do
-          #2 right then up
-          expect(@knight.proper_length?(1,3)).to be true
-          #2 right then down
-          expect(@knight.proper_length?(-1,3)).to be true
-          #2 left then up
-          expect(@knight.proper_length?(1,-1)).to be true
-          #2 left then down
-          expect(@knight.proper_length?(-1,-1)).to be true
-        end
-
-        it 'returns false for none L space' do
-          #horizontal 1 step
-          expect(@knight.proper_length?(0,2)).to be false
-          #vertical 1 step
-          expect(@knight.proper_length?(1,1)).to be false
-          #diagonal 1 step
-          expect(@knight.proper_length?(1,2)).to be false
-          #2 right then 2 up
-          expect(@knight.proper_length?(2,3)).to be false
         end
       end
 
@@ -83,11 +48,24 @@ RSpec.describe Knight, type: :model do
           expect(@knight.valid_move?(1,0)).to be true
         end
 
-        it 'returns false for invalid move' do
+        it 'returns false if out of bounds for new_row' do
           #2 down then left and out of bounds
           expect(@knight.valid_move?(-2,0)).to be false
+        end
+
+        it 'returns false if out of bounds for new_column' do
+          # reposition knight
+          @knight.position_row = 0
+          @knight.position_column = 0
+          #puts " for in bound case should return false"
+          #p @knight.out_of_boundary?(0,2)
+          #puts " for out of bound case should return true"
+          #p @knight.out_of_boundary?(-2,2)
           #2 down then right and out of bounds
-          expect(@knight.valid_move?(-2,2)).to be false
+          expect(@knight.valid_move?(2,-1)).to be false
+        end
+
+        it 'returns false for invalid move' do
           #horizontal 1 step
           expect(@knight.valid_move?(0,2)).to be false
           #vertical 1 step

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe Knight, type: :model do
         end
       end
 
+      context 'out_of_boundary?' do 
+        it 'returns true if out of bounds for new_row' do
+          #2 down then left and out of bounds
+          expect(@knight.out_of_boundary?(-2,0)).to be true
+        end
+
+        it 'returns true if out of bounds for new_column' do
+          # reposition knight
+          @knight.position_row = 0
+          @knight.position_column = 0
+          expect(@knight.out_of_boundary?(2,-1)).to be true
+        end
+      end
+
       context 'valid_move?' do 
         it 'returns true for L space vertical' do
           #2 up then left
@@ -50,7 +64,6 @@ RSpec.describe Knight, type: :model do
 
         it 'returns false if out of bounds for new_row' do
           #2 down then left and out of bounds
-          expect(@knight.out_of_boundary?(-2,0)).to be true
           expect(@knight.valid_move?(-2,0)).to be false
         end
 
@@ -58,7 +71,6 @@ RSpec.describe Knight, type: :model do
           # reposition knight
           @knight.position_row = 0
           @knight.position_column = 0
-          expect(@knight.out_of_boundary?(2,-1)).to be true
           expect(@knight.valid_move?(2,-1)).to be false
         end
 


### PR DESCRIPTION
I updated the knight valid move method with suggestions about using super. I also updated rspec tests for out_of boundary? method nested within the valid_move? method. 
Note that knight model valid_move? does not include the is_obstructed? method since it can hop over its own pieces.