### PR TITLE
added valid_move & move_to! to piece controller

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -10,8 +10,12 @@ class PiecesController < ApplicationController
     @game = Game.find(@piece.game_id)
 
     if @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
-      #will take piece off the board if captured, if not captured, this will do nothing
-      @piece.move_to!(params[:y_coord].to_i, params[:x_coord].to_i)
+      begin
+        #will take piece off the board if captured, if not captured, this will do nothing
+        @piece.move_to!(params[:y_coord].to_i, params[:x_coord].to_i)
+      rescue Exception => e
+        return redirect_to piece_path(@piece), alert: e.message
+      end
       #update the current pieces position
       @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
       redirect_to game_path(@game)

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -16,7 +16,7 @@ class PiecesController < ApplicationController
       @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
       redirect_to game_path(@game)
     else
-      redirect_to piece_path(@piece), alert: "Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position."
+      redirect_to piece_path(@piece), alert: "Invalid move for piece. Please try again."
     end
   
   end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,16 +9,10 @@ class PiecesController < ApplicationController
     #begin
       @piece = Piece.find(params[:id])
       @game = Game.find(@piece.game_id)
-      puts " "
-      puts " y coordinate type"
-      p params[:y_coord]
-      p params[:y_coord].to_i
-      p @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
-      puts @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
-      puts " "
-      #puts Piece.find(position_row: params[:y_coord], position_column: params[:x_coord], game_id: game_id)
-      puts " "
       if @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
+        #will take piece off the board if captured, if not captured, this will do nothing
+        @piece.move_to!(params[:y_coord].to_i, params[:x_coord].to_i)
+        #update the current pieces position
         @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
         redirect_to game_path(@game)
       else

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -5,24 +5,20 @@ class PiecesController < ApplicationController
     @game = Game.find(@piece.game_id)
   end
 
-  def update
-    #begin
-      @piece = Piece.find(params[:id])
-      @game = Game.find(@piece.game_id)
-      if @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
-        #will take piece off the board if captured, if not captured, this will do nothing
-        @piece.move_to!(params[:y_coord].to_i, params[:x_coord].to_i)
-        #update the current pieces position
-        @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
-        redirect_to game_path(@game)
-      else
-        raise RuntimeError, "invalid input. Not diagonal, horizontal, or vertical."
-        #raise ActionController::RoutingError.new("Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position.")
-      end
-    #rescue StandardError => e
-      #flash.now[:alert] = "Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position."
-      #render "show"
-    #end
+  def update  
+    @piece = Piece.find(params[:id])
+    @game = Game.find(@piece.game_id)
+
+    if @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
+      #will take piece off the board if captured, if not captured, this will do nothing
+      @piece.move_to!(params[:y_coord].to_i, params[:x_coord].to_i)
+      #update the current pieces position
+      @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
+      redirect_to game_path(@game)
+    else
+      redirect_to piece_path(@piece), alert: "Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position."
+    end
+  
   end
 
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -22,7 +22,7 @@ class PiecesController < ApplicationController
         @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
         redirect_to game_path(@game)
       else
-        raise RuntimeError, "invalid input. Not diagnal, horizontal, or vertical."
+        raise RuntimeError, "invalid input. Not diagonal, horizontal, or vertical."
         #raise ActionController::RoutingError.new("Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position.")
       end
     #rescue StandardError => e

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,10 +6,29 @@ class PiecesController < ApplicationController
   end
 
   def update
-    @piece = Piece.find(params[:id])
-    @game = Game.find(@piece.game_id)
-    @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
-    redirect_to game_path(@game)
+    #begin
+      @piece = Piece.find(params[:id])
+      @game = Game.find(@piece.game_id)
+      puts " "
+      puts " y coordinate type"
+      p params[:y_coord]
+      p params[:y_coord].to_i
+      p @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
+      puts @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
+      puts " "
+      #puts Piece.find(position_row: params[:y_coord], position_column: params[:x_coord], game_id: game_id)
+      puts " "
+      if @piece.valid_move?(params[:y_coord].to_i, params[:x_coord].to_i)
+        @piece.update_attributes(position_row: params[:y_coord], position_column: params[:x_coord], moves: @piece.moves + 1)
+        redirect_to game_path(@game)
+      else
+        raise RuntimeError, "invalid input. Not diagnal, horizontal, or vertical."
+        #raise ActionController::RoutingError.new("Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position.")
+      end
+    #rescue StandardError => e
+      #flash.now[:alert] = "Invalid move for piece due to obstruction, out of bounds or not correct. Please try another position."
+      #render "show"
+    #end
   end
 
 end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -5,17 +5,13 @@ class Bishop < Piece
   
   #should return false if rook unable to move
   def valid_move?(new_row, new_column)
-    #return false if unable to move
-    #return false if no_move?(new_row, new_column)
-    super
-  
-  
+    return false if !super
     #return false if bishop is blocked
     return false if is_obstructed?(new_row, new_column)
     #returns only true if moved in a diagonal
     delta_row = (new_row - position_row).abs
     delta_col = (new_column - position_column).abs
-       return true if delta_row == delta_col 
+    return true if delta_row == delta_col 
     #If we don't have a valid move return false by default
     return false 
     

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -5,7 +5,7 @@ class Bishop < Piece
   
   #should return false if rook unable to move
   def valid_move?(new_row, new_column)
-    return false if !super
+    return false if super == false
     #return false if bishop is blocked
     return false if is_obstructed?(new_row, new_column)
     #returns only true if moved in a diagonal
@@ -14,7 +14,6 @@ class Bishop < Piece
     return true if delta_row == delta_col 
     #If we don't have a valid move return false by default
     return false 
-    
   end  
   
   

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -36,7 +36,6 @@ class Piece < ApplicationRecord
   def valid_move?(new_row, new_column)
     return false if out_of_boundary?(new_row, new_column)
     return false if no_move?(new_row, new_column)
-    return true
   end
 
   def array_position(init, final)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -77,14 +77,10 @@ class Piece < ApplicationRecord
     @pieces = Game.find(game_id).pieces
     @pieces.each do |piece|
       if piece.position_row == new_row && piece.position_column == new_column && piece.color != color
-        piece.position_row = nil
-        piece.position_column = nil
-      elsif piece.position_row == new_row && piece.position_column == new_column && piece.color == color
+        piece.update_attributes(position_row: nil, position_column: nil)
+      elsif piece.position_row == new_row && piece.position_column == new_column 
         raise RuntimeError, "You can't capture your own piece!!!"
-      else
-        #when new position has no piece on it, return nothing
       end
     end
   end
-
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -68,7 +68,7 @@ class Piece < ApplicationRecord
     end
 
     #invalid input case
-    raise RuntimeError, "invalid input. Not diagnal, horizontal, or vertical."
+    raise RuntimeError, "invalid input. Not diagonal, horizontal, or vertical."
     
   end
 
@@ -79,6 +79,10 @@ class Piece < ApplicationRecord
       if piece.position_row == new_row && piece.position_column == new_column && piece.color != color
         piece.position_row = nil
         piece.position_column = nil
+      elsif piece.position_row == new_row && piece.position_column == new_column && piece.color == color
+        raise RuntimeError, "You can't capture your own piece!!!"
+      else
+        #when new position has no piece on it, return nothing
       end
     end
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -68,7 +68,7 @@ class Piece < ApplicationRecord
     end
 
     #invalid input case
-    raise RuntimeError, "invalid input. Not diagnal, horizontal, or vertical."
+    raise RuntimeError, "invalid input. Not diagonal, horizontal, or vertical."
     
   end
 
@@ -79,6 +79,8 @@ class Piece < ApplicationRecord
       if piece.position_row == new_row && piece.position_column == new_column && piece.color != color
         piece.position_row = nil
         piece.position_column = nil
+      else
+        raise RuntimeError, "You can't capture your own piece!!!"
       end
     end
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -57,15 +57,15 @@ class Piece < ApplicationRecord
 
     #horizonal case
     if row_init == row_final
-      return Piece.exists?(position_row: row_init, position_column: col_range)
+      return Piece.exists?(position_row: row_init, position_column: col_range, game_id: game_id)
 
       #vertical case
     elsif col_init == col_final 
-      return Piece.exists?(position_row: row_range, position_column: col_init)
+      return Piece.exists?(position_row: row_range, position_column: col_init, game_id: game_id)
 
       #diagonal case
     elsif ((row_final - row_init).to_f/(col_final - col_init).to_f ).abs == 1
-      return Piece.exists?(position_row: row_range, position_column: col_range)
+      return Piece.exists?(position_row: row_range, position_column: col_range, game_id: game_id)
     end
 
     #invalid input case

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -76,15 +76,9 @@ class Piece < ApplicationRecord
   def move_to!(new_row, new_column)
     @pieces = Game.find(game_id).pieces
     @pieces.each do |piece|
-      if piece.position_row == new_row && piece.position_column == new_column
-        if piece.color == color
-          #We can't move to a place where our own pieces are!
-          raise RuntimeError, "You can't capture your own piece!"
-        else
-          #Setting to nil to indicate a piece has been captured
-          piece.position_row = nil
-          piece.position_column = nil
-        end
+      if piece.position_row == new_row && piece.position_column == new_column && piece.color != color
+        piece.position_row = nil
+        piece.position_column = nil
       end
     end
   end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -5,8 +5,7 @@ class Rook < Piece
   
     #should return false if rook unable to move
   def valid_move?(new_row, new_column)
-    
-    super
+    return false if !super
     #return false if rook is blocked
     return false if is_obstructed?(new_row, new_column)
     #returns only true if moved in a column or row and it is not obstructed or a no move 

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -5,15 +5,13 @@ class Rook < Piece
   
     #should return false if rook unable to move
   def valid_move?(new_row, new_column)
-    return false if !super
+    return false if super == false
     #return false if rook is blocked
     return false if is_obstructed?(new_row, new_column)
     #returns only true if moved in a column or row and it is not obstructed or a no move 
-    return true if (new_row == self.position_row) || (new_column == self.position_column)
-    
+    return true if (new_row == self.position_row) || (new_column == self.position_column) 
     #If we don't have a valid move return false by default
     return false 
-    
   end  
   
   

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -10,13 +10,16 @@
       <td class= 'position_column' data-x-position'<%=position_column%>' data-y-position'<%=position_row%>'>
         <div class='chess_pieces'>
           <%piece = @game.data_method[position_column][position_row]%>
-
-        <% if piece == @piece %>
-            <div class='highlighted'>
-              <%=piece.symbol.html_safe%>
-            </div>
-        <% elsif piece.present? %>
-          <%=piece.symbol.html_safe%>
+          <% if piece == @piece %>
+              <div class='highlighted'>
+                <%=piece.symbol.html_safe%>
+              </div>
+          <% elsif piece.present? %>
+            <%= link_to piece_path(@piece, params: { x_coord: position_column, y_coord: position_row }),  method: "put" do %>
+              <div class = "empty_space">
+                <%=piece.symbol.html_safe%>
+              </div>
+            <% end %>
         </div>
         <% else %>
           <%= link_to piece_path(@piece, params: { x_coord: position_column, y_coord: position_row }),  method: "put" do %>

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -35,40 +35,27 @@ RSpec.describe PiecesController, type: :controller do
 
     context "move_to!" do
       it "does not capture the piece if the desired position is occupied by the same color" do
-        white_pawn1 = Pawn.second #located @ (1,1)
-        #another piece of the same color exists in the position we want to move to
-        white_pawn2 = Pawn.third #(located @(3,2)
-        white_pawn2.update_attributes(position_row: 2, position_column: 1) 
-        puts "first puts"
-        p white_pawn2
-        puts "second"
-        p white_pawn1.valid_move?(2,1)
-        #white_pawn1.move_to!(2,1)
-        puts "third"
-        p white_pawn2
-        puts "fourth"
-        p Pawn.third
-        patch :update, params: {id: white_pawn1.id, y_coord: 2, x_coord: 1, moves: white_pawn1.moves + 1}
-        puts " "
-        white_pawn1.reload
-        p white_pawn1
+        piece = Rook.first #white Rook @ position_row: 0, position_column: 0
+        piece2 = Pawn.first #white pawn @ position_row: 1, position_column: 0
 
         expect{ patch :update, 
-          params: {id: white_pawn1.id, y_coord: 2, x_coord: 1, moves: white_pawn1.moves + 1} }.to raise_error(RuntimeError)        
+          params: {id: piece.id, y_coord: 1, x_coord: 0, moves: piece.moves + 1} }.to raise_error(RuntimeError)        
         #The piece in the desired position does not update its coordinates
-        expect([white_pawn2.position_row, white_pawn2.position_column]).to eq [2,2]
+        expect([piece2.position_row, piece2.position_column]).to eq [1,0]
       end
 
       it "captures the opposing team piece if the desired position is occupied by opposing team" do
         #capture succeeds tnat that opponent piece has nil for position 
-        white_pawn1 = Pawn.second #located @(1,1)
-        black_pawn1 = Pawn.last #located @(6,7)
+        piece = Rook.first #white Rook @ position_row: 0, position_column: 0
+        piece2 = Pawn.first #white pawn @ position_row: 1, position_column: 0
+        piece2.update_attributes(color: "black") #change piece to black to test capture
 
-        white_pawn1.move_to!(6,7)
+        patch :update, params: {id: piece.id, y_coord: 1, x_coord: 0, moves: piece.moves + 1}
 
-        black_pawn1.reload
+        piece2.reload
+        expect(response).to redirect_to game_path(@game)        
         #the opposing piece should have its coordinates changed to nil, nil 
-        expect([black_pawn1.position_row, black_pawn1.position_column]).to eq [nil,nil]
+        expect([piece2.position_row, piece2.position_column]).to eq [nil,nil]
       end
     end
   end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PiecesController, type: :controller do
 
   describe "pieces#update" do
     context "when valid_move? returns false" do
-      it "responds with flash message & redirect to piece show page due to obstruction" do
+      it "responds with flash message & redirects to piece show page due to obstruction" do
         piece = Rook.first #white Rook @ position_row: 0, position_column: 0
 
         #based on how the links in the html show piece is setup, new parameters are used like so:
@@ -22,7 +22,7 @@ RSpec.describe PiecesController, type: :controller do
     end
 
     context "when valid_move? returns true" do
-      it "piece position is updated successfully & redirect to game show page" do
+      it "piece position is updated successfully & redirected to game show page" do
         piece = Pawn.first #white pawn @ position_row: 1, position_column: 0
    
         patch :update, params: {id: piece.id, y_coord: 3, x_coord: 0, moves: piece.moves + 1}
@@ -34,15 +34,26 @@ RSpec.describe PiecesController, type: :controller do
     end
 
     context "move_to!" do
-      it "does not update the piece position if a piece of the same color is present" do
+      it "does not capture the piece if the desired position is occupied by the same color" do
+        white_pawn1 = Pawn.second #located @ (1,1)
         #another piece of the same color exists in the position we want to move to
-        #my piece does not update position
-        #possibly return a flash message and redirect to the piece page
+        white_pawn2 = Pawn.third #(located @(1,2)
+
+        expect{ white_pawn1.move_to!(1,2) }.to raise_error(RuntimeError)
+        
+        #The piece in the desired position does not update its coordinates
+        expect([white_pawn2.position_row, white_pawn2.position_column]).to eq [1,2]
       end
 
-      it "captures the opposing team piece if that position is occupied" do
+      it "captures the opposing team piece if the desired position is occupied by opposing team" do
         #capture succeeds tnat that opponent piece has nil for position 
-        #my piece has that opponent's position
+        white_pawn1 = Pawn.second #located @(1,1)
+        black_pawn1 = Pawn.last #located @(6,7)
+
+        white_pawn1.move_to!(6,7)
+
+        #the opposing piece should have its coordinates changed to nil, nil 
+        expect([black_pawn1.position_row, black_pawn1.position_column]).to eq [nil,nil]
       end
     end
   end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -1,5 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe PiecesController, type: :controller do
+  before do
+    @game = Game.create(id: 1, white_player_id: 1, black_player_id: 2)
+    @game.set_pieces_on_board
+    @game.set_default_turn
+  end
 
+  describe "pieces#update" do
+    context "when valid_move? returns false" do
+      it "responds with flash message & redirect to piece show page due to obstruction" do
+        piece = Rook.first #white Rook @ position_row: 0, position_column: 0
+
+        #based on how the links in the html show piece is setup, new parameters are used like so:
+        #the position_row is y_coord: and position_column is x_coord
+        patch :update, params: {id: piece.id, y_coord: 3, x_coord: 0, moves: piece.moves + 1}
+        expect(flash[:alert]).to be_present
+        expect(response).to redirect_to piece_path(piece)
+        expect([piece.position_row,piece.position_column]).to eq [0,0]
+      end
+    end
+
+    context "when valid_move? returns true" do
+      it "piece position is updated successfully & redirect to game show page" do
+        piece = Pawn.first #white pawn @ position_row: 1, position_column: 0
+   
+        patch :update, params: {id: piece.id, y_coord: 3, x_coord: 0, moves: piece.moves + 1}
+
+        piece.reload
+        expect(response).to redirect_to game_path(@game)
+        expect([piece.position_row,piece.position_column]).to eq [3,0]
+      end
+    end
+
+    context "move_to!" do
+      it "does not update the piece position if a piece of the same color is present" do
+        #another piece of the same color exists in the position we want to move to
+        #my piece does not update position
+        #possibly return a flash message and redirect to the piece page
+      end
+
+      it "captures the opposing team piece if that position is occupied" do
+        #capture succeeds tnat that opponent piece has nil for position 
+        #my piece has that opponent's position
+      end
+    end
+  end
 end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -38,8 +38,10 @@ RSpec.describe PiecesController, type: :controller do
         piece = Rook.first #white Rook @ position_row: 0, position_column: 0
         piece2 = Pawn.first #white pawn @ position_row: 1, position_column: 0
 
-        expect{ patch :update, 
-          params: {id: piece.id, y_coord: 1, x_coord: 0, moves: piece.moves + 1} }.to raise_error(RuntimeError)        
+        patch :update, params: {id: piece.id, y_coord: 1, x_coord: 0, moves: piece.moves + 1}
+
+        expect(flash[:alert]).to be_present
+        expect(response).to redirect_to piece_path(piece)        
         #The piece in the desired position does not update its coordinates
         expect([piece2.position_row, piece2.position_column]).to eq [1,0]
       end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -37,12 +37,26 @@ RSpec.describe PiecesController, type: :controller do
       it "does not capture the piece if the desired position is occupied by the same color" do
         white_pawn1 = Pawn.second #located @ (1,1)
         #another piece of the same color exists in the position we want to move to
-        white_pawn2 = Pawn.third #(located @(1,2)
+        white_pawn2 = Pawn.third #(located @(3,2)
+        white_pawn2.update_attributes(position_row: 2, position_column: 1) 
+        puts "first puts"
+        p white_pawn2
+        puts "second"
+        p white_pawn1.valid_move?(2,1)
+        #white_pawn1.move_to!(2,1)
+        puts "third"
+        p white_pawn2
+        puts "fourth"
+        p Pawn.third
+        patch :update, params: {id: white_pawn1.id, y_coord: 2, x_coord: 1, moves: white_pawn1.moves + 1}
+        puts " "
+        white_pawn1.reload
+        p white_pawn1
 
-        expect{ white_pawn1.move_to!(1,2) }.to raise_error(RuntimeError)
-        
+        expect{ patch :update, 
+          params: {id: white_pawn1.id, y_coord: 2, x_coord: 1, moves: white_pawn1.moves + 1} }.to raise_error(RuntimeError)        
         #The piece in the desired position does not update its coordinates
-        expect([white_pawn2.position_row, white_pawn2.position_column]).to eq [1,2]
+        expect([white_pawn2.position_row, white_pawn2.position_column]).to eq [2,2]
       end
 
       it "captures the opposing team piece if the desired position is occupied by opposing team" do
@@ -52,6 +66,7 @@ RSpec.describe PiecesController, type: :controller do
 
         white_pawn1.move_to!(6,7)
 
+        black_pawn1.reload
         #the opposing piece should have its coordinates changed to nil, nil 
         expect([black_pawn1.position_row, black_pawn1.position_column]).to eq [nil,nil]
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,5 +20,25 @@ FactoryGirl.define do
   factory :king do
     association :piece
   end
+
+  factory :queen do
+    association :piece
+  end
+
+  factory :rook do
+    association :piece
+  end
   
+  factory :bishop do
+    association :piece
+  end
+
+  factory :knight do
+    association :piece
+  end
+
+  factory :pawn do
+    association :piece
+  end
+
 end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -26,25 +26,25 @@ RSpec.describe Bishop, type: :model do
     context 'is_obstructed?' do 
       it 'returns true if we are obstructed' do
         #since bishop3 is blocked by a pawn expect to be obsstructed.
-        Pawn.all.update_all(position_row: 6, position_column: 4)  
+        Pawn.update_all(position_row: 6, position_column: 4)  
         expect(@bishop3.is_obstructed?(2,0)).to be true
       end
 
       it 'returns false if we are not obstructed' do
         #clear the pawns so the bishop can move
-        Pawn.all.update_all(position_row: nil, position_column: nil)
+        Pawn.update_all(position_row: nil, position_column: nil)
         expect(@bishop1.is_obstructed?(1,1)).to be false
       end
     end
 
      context 'valid_move?' do 
       it 'allows us to move  forward if not obstructed' do
-        Pawn.all.update_all(position_row: nil, position_column: nil)
+        Pawn.update_all(position_row: nil, position_column: nil)
         expect(@bishop1.valid_move?(4,6)).to be true
       end
 
       it 'does not allow moving unless straight column or row' do
-        Pawn.all.update_all(position_row: nil, position_column: nil)
+        Pawn.update_all(position_row: nil, position_column: nil)
         #moving rook like bishop checking if valid
         expect(@bishop1.valid_move?(0,1)).to be false
       end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -73,4 +73,29 @@ RSpec.describe Piece, type: :model do
       expect{ check = pawn.is_obstructed?(1,2) }.to raise_error(RuntimeError)
     end
   end
+
+  describe "move_to!" do
+      it "does not capture the piece if the desired position is occupied by the same color" do
+        white_pawn1 = Pawn.second #located @ (1,1)
+        #another piece of the same color exists in the position we want to move to
+        white_pawn2 = Pawn.third #(located @(1,2)
+
+        expect{ white_pawn1.move_to!(1,2) }.to raise_error(RuntimeError)
+        
+        #The piece in the desired position does not update its coordinates
+        expect([white_pawn2.position_row, white_pawn2.position_column]).to eq [1,2]
+      end
+
+      it "captures the opposing team piece if the desired position is occupied by opposing team" do
+        #capture succeeds tnat that opponent piece has nil for position 
+        white_pawn1 = Pawn.second #located @(1,1)
+        black_pawn1 = Pawn.last #located @(6,7)
+
+        white_pawn1.move_to!(6,7)
+
+        black_pawn1.reload
+        #the opposing piece should have its coordinates changed to nil, nil 
+        expect([black_pawn1.position_row, black_pawn1.position_column]).to eq [nil,nil]
+      end
+    end
 end


### PR DESCRIPTION
Ready for review.

valid_move? is now called in the piece controller and move_to! captures a piece by setting the captured piece's coordinates to (nil,nil).

We have some new rspec tests in the file called pieces_controller_spec.rb so you can run the tests in your console with bundle exec rspec.

Furthermore, you can now capture pieces in the web browser. @smiths15 @JefeNelson we altered the code for the pieces show page such that a piece could move to an occupied spot (before, you could only move to an empty space). Not sure if this will be of use to you guys when changing the code to javascript.

Thanks!


